### PR TITLE
Add in-memory cart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Catálogo Bees Query API
 
-API em Node.js (ESM) que expõe uma busca fuzzy sobre um catálogo de produtos carregado a partir de um arquivo JSON. O objetivo é permitir consultas por proximidade, levando em consideração tokens do nome, tamanhos e informações de embalagem.
+API em Node.js (ESM) que expõe uma busca fuzzy sobre um catálogo de produtos carregado a partir de um arquivo JSON. O objetivo é permitir consultas por proximidade, levando em consideração tokens do nome, tamanhos e informações de embalagem. O projeto também inclui um módulo de carrinho em memória para simular operações básicas de checkout.
 
 ## Tecnologias
 
@@ -17,6 +17,7 @@ API em Node.js (ESM) que expõe uma busca fuzzy sobre um catálogo de produtos c
 ├── README.md
 └── src
     ├── catalog.js
+    ├── cart.js
     ├── search.js
     ├── server.js
     ├── synonyms.js
@@ -85,6 +86,82 @@ Resposta de exemplo:
 
 Máximo de 5 itens são retornados, ordenados pelo score em ordem decrescente.
 
+### `POST /cart/items`
+
+Adiciona ou atualiza itens em um carrinho mantido em memória. Quantidades são sobrescritas; enviar `qty = 0` remove o item do carrinho.
+
+**Body (JSON):**
+
+```json
+{
+  "cart_id": "opcional",
+  "items": [
+    { "item_platform_id": "V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM=", "qty": 3 },
+    { "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMjY3NTg=", "qty": 0 }
+  ]
+}
+```
+
+**Resposta (200):**
+
+```json
+{
+  "cart_id": "CART-1234",
+  "status": "ok",
+  "items": [
+    { "item_platform_id": "V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM=", "qty": 3 },
+    { "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMjY3NTg=", "qty": 0, "removed": true }
+  ]
+}
+```
+
+Validações aplicadas:
+
+- `items` deve ser um array;
+- cada `qty` precisa ser inteiro maior ou igual a zero;
+- `item_platform_id` deve existir no catálogo carregado.
+
+Itens inválidos retornam erro 400 seguindo o formato:
+
+```json
+{
+  "status": "error",
+  "invalid": [
+    { "item_platform_id": "XYZ", "reason": "not_found_in_catalog" },
+    { "item_platform_id": "ABC", "reason": "qty_must_be_integer_gte_0" }
+  ]
+}
+```
+
+### `GET /cart/:cartId/subtotal`
+
+Retorna as linhas do carrinho enriquecidas com dados do catálogo e o subtotal calculado.
+
+**Resposta (200):**
+
+```json
+{
+  "cart_id": "CART-1234",
+  "currency": "BRL",
+  "lines": [
+    {
+      "item_platform_id": "V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM=",
+      "name": "Cerveja Spaten Munich Helles Lata 350ml Pack UN",
+      "variant": "350ml",
+      "pack": "Unidade",
+      "price": 4.79,
+      "qty": 3,
+      "line_total": 14.37
+    }
+  ],
+  "subtotal": 14.37
+}
+```
+
+Carrinhos inexistentes retornam `404` com `{ "status": "not_found", "message": "Cart not found" }`.
+
+Os carrinhos são temporários e possuem TTL de 24h desde o último acesso ou alteração.
+
 ## Formato do catálogo
 
 O arquivo `catalogo.json` deve conter um array de objetos com os campos:
@@ -96,22 +173,24 @@ O arquivo `catalogo.json` deve conter um array de objetos com os campos:
 - `source_vendor_item_id`
 - `product_sku`
 - `item_platform_id`
+- `price`
 
 Exemplo de item:
 
 ```json
 {
-  "name": "Cerveja Brahma Chopp Descartável 350ml Caixa c/ 12 un",
-  "pack_name": "CX",
+  "name": "Cerveja Spaten Munich Helles Lata 350ml Pack UN",
+  "pack_name": "UN",
   "container_item_size": "350.00000",
   "container_unit_of_measurement": "ml",
-  "source_vendor_item_id": "0013079",
-  "product_sku": "0013079",
-  "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMTMwNzk="
+  "source_vendor_item_id": "0019023",
+  "product_sku": "0019023",
+  "item_platform_id": "V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM=",
+  "price": 4.79
 }
 ```
 
-Durante o carregamento, o tamanho é convertido para número e derivadas úteis são preparadas para busca (tokens, normalização, etc.).
+Durante o carregamento, o tamanho é convertido para número e derivadas úteis são preparadas para busca (tokens, normalização, etc.). Também são calculados os campos `variant`, `pack`, `price` (como número) e `price_missing` para uso no carrinho.
 
 ## Exemplos de consulta
 
@@ -127,3 +206,4 @@ curl "http://localhost:3001/catalog/search?q=duplo%20malte%20550ml%20caixa"
 - A pontuação final varia entre 0 e 1, combinando tokens (60%), tamanho (25%) e embalagem (15%).
 - Quando o tamanho não é informado, um valor neutro de 0.7 é aplicado para evitar penalidades.
 - A detecção de aliases como “latão” e “long neck” atribui tamanhos padrão (473 ml e 355 ml, respectivamente).
+- O carrinho é mantido somente em memória; reiniciar o processo limpa todos os carrinhos.

--- a/catalogo.json
+++ b/catalogo.json
@@ -6,7 +6,8 @@
     "container_unit_of_measurement": "ml",
     "source_vendor_item_id": "0026758",
     "product_sku": "0026758",
-    "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMjY3NTg="
+    "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMjY3NTg=",
+    "price": 38.9
   },
   {
     "name": "Cerveja Brahma Chopp Descartável 350ml Caixa c/ 12 un",
@@ -15,7 +16,8 @@
     "container_unit_of_measurement": "ml",
     "source_vendor_item_id": "0013079",
     "product_sku": "0013079",
-    "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMTMwNzk="
+    "item_platform_id": "Y3hLeTI3QW9TOW1kaXFqUG9BWUNuZz09OzAwMTMwNzk=",
+    "price": 3.29
   },
   {
     "name": "Cerveja Brahma Duplo Malte Latao 473ml Fardo c/ 12",
@@ -24,7 +26,8 @@
     "container_unit_of_measurement": "ml",
     "source_vendor_item_id": "0102045",
     "product_sku": "0102045",
-    "item_platform_id": "c0xUc1pUR0tBUnRJSDR5ZVlDV2hKdz09OzAxMDIwNDU="
+    "item_platform_id": "c0xUc1pUR0tBUnRJSDR5ZVlDV2hKdz09OzAxMDIwNDU=",
+    "price": 4.99
   },
   {
     "name": "Cerveja Skol Pilsen Long Neck 355ml Caixa c/ 12",
@@ -33,7 +36,8 @@
     "container_unit_of_measurement": "ml",
     "source_vendor_item_id": "0009871",
     "product_sku": "0009871",
-    "item_platform_id": "TTZKT1FUR0txYk1WdXhZQ0Y2ZVdSQT09OzAwMDk4NzE="
+    "item_platform_id": "TTZKT1FUR0txYk1WdXhZQ0Y2ZVdSQT09OzAwMDk4NzE=",
+    "price": 3.59
   },
   {
     "name": "Cerveja Spaten Munich Helles Lata 350ml Pack UN",
@@ -42,6 +46,7 @@
     "container_unit_of_measurement": "ml",
     "source_vendor_item_id": "0019023",
     "product_sku": "0019023",
-    "item_platform_id": "V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM="
+    "item_platform_id": "V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM=",
+    "price": 4.79
   }
 ]

--- a/src/cart.js
+++ b/src/cart.js
@@ -1,0 +1,138 @@
+import crypto from 'crypto';
+import { findByItemPlatformId } from './catalog.js';
+import { formatPackDescription, formatVariantFromSize } from './utils.js';
+
+const CART_ID_PREFIX = 'CART-';
+const CART_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+const carts = new Map(); // cartId -> Map(item_platform_id -> qty)
+const cartMeta = new Map(); // cartId -> last access timestamp
+
+// Gera identificadores consistentes para novos carrinhos.
+function generateCartId() {
+  if (typeof crypto.randomUUID === 'function') {
+    return `${CART_ID_PREFIX}${crypto.randomUUID()}`;
+  }
+  const random = Math.random().toString(36).slice(2, 10).toUpperCase();
+  return `${CART_ID_PREFIX}${random}`;
+}
+
+// Recupera a estrutura de itens existente ou cria uma nova.
+function ensureCart(cartId) {
+  let cart = carts.get(cartId);
+  if (!cart) {
+    cart = new Map();
+    carts.set(cartId, cart);
+  }
+  return cart;
+}
+
+// Atualiza o timestamp de acesso para controles de TTL.
+function markAccess(cartId, timestamp = Date.now()) {
+  cartMeta.set(cartId, timestamp);
+}
+
+// Limpa carrinhos expirados da memória.
+function purgeExpiredCarts(now = Date.now()) {
+  for (const [cartId, lastAccess] of cartMeta.entries()) {
+    if (lastAccess + CART_TTL_MS <= now) {
+      cartMeta.delete(cartId);
+      carts.delete(cartId);
+    }
+  }
+}
+
+// Normaliza valores monetários para duas casas decimais.
+function toMoney(value) {
+  const numeric = Number.isFinite(value) ? value : 0;
+  return Number(numeric.toFixed(2));
+}
+
+// Adiciona ou sobrescreve itens em um carrinho em memória.
+export function upsertItems(cartIdOrNull, items) {
+  purgeExpiredCarts();
+  const providedId = typeof cartIdOrNull === 'string' && cartIdOrNull.trim() ? cartIdOrNull.trim() : null;
+  const cartId = providedId || generateCartId();
+  const cart = ensureCart(cartId);
+  const now = Date.now();
+
+  const updatedItems = items.map(({ item_platform_id, qty }) => {
+    if (qty === 0) {
+      cart.delete(item_platform_id);
+      markAccess(cartId, now);
+      return { item_platform_id, qty, removed: true };
+    }
+
+    cart.set(item_platform_id, qty);
+    markAccess(cartId, now);
+    return { item_platform_id, qty };
+  });
+
+  if (cart.size === 0) {
+    // Remove completamente carrinhos vazios para evitar acumular estado
+    carts.delete(cartId);
+    cartMeta.delete(cartId);
+  }
+
+  return { cartId, items: updatedItems };
+}
+
+// Retorna as linhas do carrinho enriquecidas com dados do catálogo.
+export function getCartLines(cartId) {
+  purgeExpiredCarts();
+  const cart = carts.get(cartId);
+  if (!cart) return null;
+
+  const now = Date.now();
+  markAccess(cartId, now);
+
+  const lines = [];
+  for (const [itemId, qty] of cart.entries()) {
+    const catalogItem = findByItemPlatformId(itemId);
+    if (!catalogItem) {
+      continue;
+    }
+
+    const price = Number.isFinite(catalogItem.price) ? catalogItem.price : 0;
+    const lineTotal = toMoney(price * qty);
+    const line = {
+      item_platform_id: itemId,
+      name: catalogItem.name,
+      variant: catalogItem.variant || formatVariantFromSize(catalogItem.size_ml),
+      pack: catalogItem.pack || formatPackDescription(catalogItem.pack_name, catalogItem.name),
+      price,
+      qty,
+      line_total: lineTotal
+    };
+
+    if (catalogItem.price_missing) {
+      line.price_missing = true;
+    }
+
+    lines.push(line);
+  }
+
+  return lines;
+}
+
+// Calcula o subtotal atual do carrinho.
+export function getSubtotal(cartId) {
+  purgeExpiredCarts();
+  const cart = carts.get(cartId);
+  if (!cart) return null;
+
+  const now = Date.now();
+  markAccess(cartId, now);
+
+  let subtotal = 0;
+  for (const [itemId, qty] of cart.entries()) {
+    const catalogItem = findByItemPlatformId(itemId);
+    if (!catalogItem) {
+      continue;
+    }
+    const price = Number.isFinite(catalogItem.price) ? catalogItem.price : 0;
+    subtotal += price * qty;
+  }
+
+  return toMoney(subtotal);
+}

--- a/src/search.js
+++ b/src/search.js
@@ -6,7 +6,8 @@ import {
   parseSizeFromQuery,
   clamp,
   detectPackKeyword,
-  formatPackDescription
+  formatPackDescription,
+  formatVariantFromSize
 } from './utils.js';
 import { ALIASES, BRANDS, PACK_SYNONYMS } from './synonyms.js';
 
@@ -83,14 +84,6 @@ function computeTokenScore(queryTokens, itemTokens) {
   return clamp(overlap + brandBonus, 0, 1);
 }
 
-function formatVariant(sizeMl) {
-  if (!sizeMl) return null;
-  const rounded = Number.isInteger(sizeMl)
-    ? sizeMl.toString()
-    : sizeMl.toFixed(1).replace(/\.0$/, '');
-  return `${rounded}ml`;
-}
-
 export function searchCatalog(query, limit = 5) {
   const normalizedQuery = normalizeText(query || '');
   const queryTokens = uniqueTokens(tokenize(query || ''));
@@ -118,8 +111,8 @@ export function searchCatalog(query, limit = 5) {
     .map(({ item, score }) => ({
       product_id: item.product_sku || item.source_vendor_item_id,
       name: item.name,
-      variant: formatVariant(item.size_ml),
-      pack: formatPackDescription(item.pack_name, item.name),
+      variant: item.variant || formatVariantFromSize(item.size_ml),
+      pack: item.pack || formatPackDescription(item.pack_name, item.name),
       score: Number(score.toFixed(4))
     }));
 

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,8 @@ import cors from 'cors';
 import morgan from 'morgan';
 import dotenv from 'dotenv';
 import { searchCatalog } from './search.js';
+import { upsertItems, getCartLines, getSubtotal } from './cart.js';
+import { findByItemPlatformId } from './catalog.js';
 
 dotenv.config();
 
@@ -10,6 +12,7 @@ const app = express();
 
 app.use(cors());
 app.use(morgan('dev'));
+app.use(express.json({ limit: '2mb' }));
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
@@ -30,6 +33,77 @@ app.get('/catalog/search', (req, res) => {
     console.error('Erro ao buscar catálogo:', error);
     res.status(500).json({ error: 'Erro interno ao processar a busca.' });
   }
+});
+
+app.post('/cart/items', (req, res) => {
+  const { cart_id: rawCartId, items } = req.body || {};
+
+  if (!Array.isArray(items)) {
+    return res.status(400).json({
+      status: 'error',
+      invalid: [{ reason: 'items_must_be_array' }]
+    });
+  }
+
+  const invalid = [];
+  const validItems = [];
+
+  for (const payload of items) {
+    const itemId = typeof payload?.item_platform_id === 'string' ? payload.item_platform_id.trim() : '';
+    const qty = payload?.qty;
+
+    if (!itemId) {
+      invalid.push({ reason: 'item_platform_id_required' });
+      continue;
+    }
+
+    if (!Number.isInteger(qty) || qty < 0) {
+      invalid.push({ item_platform_id: itemId, reason: 'qty_must_be_integer_gte_0' });
+      continue;
+    }
+
+    const catalogItem = findByItemPlatformId(itemId);
+    if (!catalogItem) {
+      invalid.push({ item_platform_id: itemId, reason: 'not_found_in_catalog' });
+      continue;
+    }
+
+    validItems.push({ item_platform_id: itemId, qty });
+  }
+
+  if (invalid.length > 0) {
+    return res.status(400).json({
+      status: 'error',
+      invalid
+    });
+  }
+
+  const cartId = typeof rawCartId === 'string' && rawCartId.trim() ? rawCartId.trim() : null;
+  const { cartId: finalCartId, items: updatedItems } = upsertItems(cartId, validItems);
+
+  return res.json({
+    cart_id: finalCartId,
+    status: 'ok',
+    items: updatedItems
+  });
+});
+
+app.get('/cart/:cartId/subtotal', (req, res) => {
+  const { cartId } = req.params;
+  const lines = getCartLines(cartId);
+
+  if (lines === null) {
+    return res.status(404).json({ status: 'not_found', message: 'Cart not found' });
+  }
+
+  const subtotal = getSubtotal(cartId);
+
+  return res.json({
+    cart_id: cartId,
+    currency: 'BRL',
+    lines,
+    subtotal
+  });
 });
 
 const PORT = process.env.PORT || 3001;

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,6 +47,14 @@ export function convertToMilliliters(value, unit) {
   return amount;
 }
 
+export function formatVariantFromSize(sizeMl) {
+  if (!Number.isFinite(sizeMl)) return null;
+  const rounded = Number.isInteger(sizeMl)
+    ? sizeMl.toString()
+    : sizeMl.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
+  return `${rounded}ml`;
+}
+
 export function clamp(value, min = 0, max = 1) {
   return Math.min(max, Math.max(min, value));
 }


### PR DESCRIPTION
## Summary
- add an in-memory cart module with TTL management and subtotal calculations
- expose POST /cart/items and GET /cart/:cartId/subtotal routes alongside catalog search
- enrich catalog items with pricing metadata and document the new cart capabilities

## Testing
- node --input-type=module -e "import { upsertItems, getCartLines, getSubtotal } from './src/cart.js'; const { cartId } = upsertItems(null, [{ item_platform_id: 'V1RVeFpUUTVOV1psT0d0bGNUTmpPQT09OzAwMTkwMjM=', qty: 2 }]); console.log('cart', cartId); console.log('lines', getCartLines(cartId)); console.log('subtotal', getSubtotal(cartId));"


------
https://chatgpt.com/codex/tasks/task_e_68ddf03adbd48333b6775d40a38d41f9